### PR TITLE
Standardized syntax

### DIFF
--- a/src/components/SlackSignup.tsx
+++ b/src/components/SlackSignup.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 
 interface Props {}
 
-const _emailRegex = /^[-!#$%&'*+\/0-9=?A-Z^_a-z{|}~](\.?[-!#$%&'*+\/0-9=?A-Z^_a-z`{|}~])*@[a-zA-Z0-9](-*\.?[a-zA-Z0-9])*\.[a-zA-Z](-?[a-zA-Z0-9])+$/;
+const emailRegex = /^[-!#$%&'*+\/0-9=?A-Z^_a-z{|}~](\.?[-!#$%&'*+\/0-9=?A-Z^_a-z`{|}~])*@[a-zA-Z0-9](-*\.?[a-zA-Z0-9])*\.[a-zA-Z](-?[a-zA-Z0-9])+$/;
 
 const EmailInput = styled.input<{ hasError: boolean }>`
   border-color: ${props => (props.hasError ? "red" : "grey")};
@@ -24,7 +24,7 @@ const SlackSignup: React.FC<Props> = () => {
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    if (!_validateEmail(email)) {
+    if (!validateEmail(email)) {
       setError("Invalid email address");
       return;
     }
@@ -71,11 +71,11 @@ const SlackSignup: React.FC<Props> = () => {
   );
 };
 
-const _validateEmail = (email: string): boolean => {
+const validateEmail = (email: string): boolean => {
   if (!email) return false;
   if (email.length > 254) return false;
 
-  const valid = _emailRegex.test(email);
+  const valid = emailRegex.test(email);
   if (!valid) return false;
 
   // Further checking of some things regex can't handle

--- a/src/components/SlackSignup.tsx
+++ b/src/components/SlackSignup.tsx
@@ -4,9 +4,13 @@ import styled from "styled-components";
 
 interface Props {}
 
-const emailRegex = /^[-!#$%&'*+\/0-9=?A-Z^_a-z{|}~](\.?[-!#$%&'*+\/0-9=?A-Z^_a-z`{|}~])*@[a-zA-Z0-9](-*\.?[a-zA-Z0-9])*\.[a-zA-Z](-?[a-zA-Z0-9])+$/;
+const _emailRegex = /^[-!#$%&'*+\/0-9=?A-Z^_a-z{|}~](\.?[-!#$%&'*+\/0-9=?A-Z^_a-z`{|}~])*@[a-zA-Z0-9](-*\.?[a-zA-Z0-9])*\.[a-zA-Z](-?[a-zA-Z0-9])+$/;
 
-const SlackSignup: React.FC<Props> = function() {
+const EmailInput = styled.input<{ hasError: boolean }>`
+  border-color: ${props => (props.hasError ? "red" : "grey")};
+`;
+
+const SlackSignup: React.FC<Props> = () => {
   const [email, setEmail] = useState("");
   const [error, setError] = useState("");
   const [submitting, setSubmitting] = useState(false);
@@ -20,7 +24,7 @@ const SlackSignup: React.FC<Props> = function() {
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    if (!validateEmail(email)) {
+    if (!_validateEmail(email)) {
       setError("Invalid email address");
       return;
     }
@@ -67,17 +71,11 @@ const SlackSignup: React.FC<Props> = function() {
   );
 };
 
-export default SlackSignup;
-
-const EmailInput = styled.input<{ hasError: boolean }>`
-  border-color: ${props => (props.hasError ? "red" : "grey")};
-`;
-
-function validateEmail(email: string): boolean {
+const _validateEmail = (email: string): boolean => {
   if (!email) return false;
   if (email.length > 254) return false;
 
-  const valid = emailRegex.test(email);
+  const valid = _emailRegex.test(email);
   if (!valid) return false;
 
   // Further checking of some things regex can't handle
@@ -88,4 +86,6 @@ function validateEmail(email: string): boolean {
   if (domainParts.some(part => part.length > 63)) return false;
 
   return true;
-}
+};
+
+export default SlackSignup;

--- a/src/components/UpcomingEvents.tsx
+++ b/src/components/UpcomingEvents.tsx
@@ -6,7 +6,7 @@ interface Props {
   maxEvents?: number;
 }
 
-const UpcomingEvents: React.FC<Props> = function({ maxEvents }) {
+const UpcomingEvents: React.FC<Props> = ({ maxEvents }) => {
   const events = useEvents();
 
   if (events.length === 0) {
@@ -22,8 +22,6 @@ const UpcomingEvents: React.FC<Props> = function({ maxEvents }) {
     .slice(0, maxEvents);
   return <ul>{renderEvents(upcomingEvents)}</ul>;
 };
-
-export default UpcomingEvents;
 
 function renderEvents(events: ASGEvent[]) {
   return events.map(event => {
@@ -52,3 +50,5 @@ function renderEvents(events: ASGEvent[]) {
     );
   });
 }
+
+export default UpcomingEvents;

--- a/src/components/asg.tsx
+++ b/src/components/asg.tsx
@@ -20,8 +20,10 @@ const AsgText = styled.h1`
  * Striped acronym header
  * @param props requires headerTitle
  */
-export const Asg = () => (
+const Asg: React.FC = () => (
   <Link to="/">
     <AsgText>ASG</AsgText>
   </Link>
 );
+
+export default Asg

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import styled from "styled-components";
 
+import Asg from "./Asg";
+import Nav from "./Nav";
 import { primaryColor } from "../styles/colors";
-import { Asg } from "../components/asg";
-import { Nav } from "../components/nav";
 import { Container } from "../styles/alignment";
 
 const StyledHeader = styled.header`
@@ -13,7 +13,7 @@ const StyledHeader = styled.header`
 /**
  * Sets max width, centering, and alignment for header. Extends Container
  */
-export const HeaderContainer = styled(Container)`
+const HeaderContainer = styled(Container)`
   align-items: center;
   display: flex;
   flex-direction: row;
@@ -23,7 +23,7 @@ export const HeaderContainer = styled(Container)`
 /**
  * Top header
  */
-const Header = () => (
+const Header: React.FC = () => (
   <StyledHeader>
     <HeaderContainer>
       <Asg />

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1,17 +1,17 @@
 import React from "react";
 import { TypographyStyle, GoogleFont } from "react-typography";
 
-import Header from "./header";
+import Header from "./Header";
 import typography from "../styles/typography";
 
-interface ILayoutProps {
+interface Props {
   children: JSX.Element[] | JSX.Element;
 }
 
 /**
  * Adds typography and header.  Sets width using Container
  */
-const Layout = ({ children }: ILayoutProps) => (
+const Layout: React.FC<Props> = ({ children }) => (
   <>
     <TypographyStyle typography={typography} />
     <GoogleFont typography={typography} />

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -5,10 +5,12 @@ import { NavLink } from "../styles/typography";
 /**
  * List of nav links in the header
  */
-export const Nav = () => (
+const Nav: React.FC = () => (
   <div>
     {["events", "about", "join"].map(x => (
       <NavLink key={x} to={`#${x}`}>{x}</NavLink>
     ))}
   </div>
 );
+
+export default Nav;

--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -1,9 +1,8 @@
 import React from "react";
-import PropTypes from "prop-types";
 import Helmet from "react-helmet";
 import { StaticQuery, graphql } from "gatsby";
 
-interface ISEOProps {
+interface Props {
   description?: string;
   lang?: string;
   meta?: any[];
@@ -11,13 +10,13 @@ interface ISEOProps {
   title: string;
 }
 
-function SEO({
+const SEO: React.FC<Props> = ({
   description,
   lang = `en`,
   meta = [],
   keywords = [],
   title,
-}: ISEOProps) {
+}) => {
   return (
     <StaticQuery
       query={detailsQuery}
@@ -85,9 +84,7 @@ function SEO({
       }}
     />
   );
-}
-
-export default SEO;
+};
 
 const detailsQuery = graphql`
   query DefaultSEOQuery {
@@ -99,3 +96,5 @@ const detailsQuery = graphql`
     }
   }
 `;
+
+export default SEO;

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
-import Layout from "../components/layout";
-import SEO from "../components/seo";
+import Layout from "../components/Layout";
+import SEO from "../components/Seo";
 
 const NotFoundPage = () => (
   <Layout>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 
-import Layout from "../components/layout";
-import SEO from "../components/seo";
-import { Banner } from "../sections/banner";
-import { About } from "../sections/about";
-import { Events } from "../sections/events";
-import { Join } from "../sections/join";
+import Layout from "../components/Layout";
+import SEO from "../components/Seo";
+import Banner from "../sections/Banner";
+import About from "../sections/About";
+import Events from "../sections/Events";
+import Join from "../sections/Join";
 
-const IndexPage = () => (
+const IndexPage: React.FC = () => (
   <Layout>
     <SEO
       title="Home"
@@ -22,8 +22,8 @@ const IndexPage = () => (
       ]}
     />
     <Banner />
-    <About />
     <Events />
+    <About />
     <Join />
   </Layout>
 );

--- a/src/pages/temp.tsx
+++ b/src/pages/temp.tsx
@@ -1,17 +1,11 @@
 import React from "react";
 
-import Layout from "../components/layout";
-import UpcomingEvents from "../components/UpcomingEvents";
-import SlackSignup from "../components/SlackSignup";
+import Layout from "../components/Layout";
 
-const IndexPage = () => (
+const Temp: React.FC = () => (
   <Layout>
     <h1>this is a temporary page for testing the stuff</h1>
-    <hr />
-    <SlackSignup />
-    <hr />
-    <UpcomingEvents maxEvents={2} />
   </Layout>
 );
 
-export default IndexPage;
+export default Temp;

--- a/src/sections/about.tsx
+++ b/src/sections/about.tsx
@@ -3,9 +3,11 @@ import React from "react";
 import { Container } from "../styles/alignment";
 import { SectionHeader } from "../styles/typography";
 
-export const About = () => (
+const About: React.FC = () => (
   <Container>
     <SectionHeader>About</SectionHeader>
     <p>About us... let's refrain from going full "bon-temps-roulez" here</p>
   </Container>
 );
+
+export default About;

--- a/src/sections/banner.tsx
+++ b/src/sections/banner.tsx
@@ -9,7 +9,7 @@ const BannerText = styled.h1`
   color: white;
   font-size: 5em;
   font-weight: 900;
-  letter-spacing: .05em;
+  letter-spacing: 0.05em;
   text-align: center;
   text-shadow: ${textStriper({
     colorArray: [stripes.yellow, stripes.red],
@@ -18,10 +18,12 @@ const BannerText = styled.h1`
   text-transform: uppercase;
 `;
 
-export const Banner = () => (
+const Banner: React.FC = () => (
   <BannerText>
     Acadiana
     <br />
     Software Group
   </BannerText>
 );
+
+export default Banner;

--- a/src/sections/events.tsx
+++ b/src/sections/events.tsx
@@ -2,10 +2,13 @@ import React from "react";
 
 import { Container } from "../styles/alignment";
 import { SectionHeader } from "../styles/typography";
+import UpcomingEvents from "../components/UpcomingEvents";
 
-export const Events = () => (
+const Events: React.FC = () => (
   <Container>
     <SectionHeader>Events</SectionHeader>
-    <p>Let's throw a calendar or something in here</p>
+    <UpcomingEvents maxEvents={2} />
   </Container>
 );
+
+export default Events;

--- a/src/sections/join.tsx
+++ b/src/sections/join.tsx
@@ -1,11 +1,14 @@
 import React from "react";
 
+import SlackSignup from "../components/SlackSignup";
 import { SectionHeader } from "../styles/typography";
 import { Container } from "../styles/alignment";
 
-export const Join = () => (
+const Join: React.FC = () => (
   <Container>
     <SectionHeader>Join</SectionHeader>
-    <p>Join us.  Slack stuff here? </p>
+    <SlackSignup />
   </Container>
 );
+
+export default Join;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2743,6 +2743,11 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+date-fns@^1.30.1:
+  version "1.30.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
+  integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
+
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
@@ -9845,6 +9850,11 @@ wrap-ansi@^2.0.0:
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+
+wretch@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/wretch/-/wretch-1.5.0.tgz#7a6f6ac38b92b65ecbb70d95d677f45026c93a2d"
+  integrity sha512-iUsTdcjgPnGjeVa+uz5fKZWh8bxlJtp+3H/hpYHTk8FBvf2VBBv2z9eb7+7ZuAI7QRxEsABOqpxLaPO21o6hlw==
 
 write-file-atomic@^2.0.0:
   version "2.4.2"


### PR DESCRIPTION
Standardized the codebase a bit:
- Arrow functions
- React.FC types
- `Props` used for props interface names
- `export default` used for components
- Capitalized all component filenames
- Private variables prefixed with underscore
- Reordered imports (packages, components, styles)