### PR TITLE
Added main-stripe

### DIFF
--- a/src/components/MainStripe.tsx
+++ b/src/components/MainStripe.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import styled from "styled-components";
+
+import { stripes } from "../styles/colors";
+
+interface StripeSvgProps {
+  index: number;
+}
+
+interface StripeProps {
+  color: string;
+  index: number;
+}
+
+/**
+ * Contains all of the main stripes
+ */
+const StripesContainer = styled.div`
+  position: relative;
+  height: 25vw;
+  overflow: hidden;
+  width: 100%;
+  z-index: -1;
+`;
+
+/**
+ * Sets clipping path so stripes can overlap
+ */
+const ClippingPath = styled.div`
+  position: relative;
+  margin-top: -20vw;
+`;
+
+/**
+ * Generates an svg with dynamic alignment
+ */
+const StripeSvg = styled.svg(
+  (props: StripeSvgProps) => `
+  position: absolute;
+  top: ${props.index * 10}px;
+  width: 100%;
+  height: 40vw;
+  z-index: -${props.index};
+`
+);
+
+const makeStripe: React.FC<StripeProps> = ({ color, index }) => (
+  <StripeSvg
+    index={index}
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 100 200"
+    preserveAspectRatio="none"
+  >
+    <polygon fill={color} points="0,0 0,200 100,110 100,0" />
+  </StripeSvg>
+);
+
+const MainStripe: React.FC = () => (
+  <StripesContainer>
+    <ClippingPath>
+      {[
+        stripes.blue,
+        stripes.white,
+        stripes.yellow,
+        stripes.red,
+        stripes.blue,
+      ].map((color: string, index: number) => makeStripe({ color, index }))}
+    </ClippingPath>
+  </StripesContainer>
+);
+
+export default MainStripe;

--- a/src/components/MainStripe.tsx
+++ b/src/components/MainStripe.tsx
@@ -44,6 +44,10 @@ const StripeSvg = styled.svg(
 `
 );
 
+/**
+ * Generates stripes for MainStripe.
+ * @param: props. First color is used for background above stripes
+ */
 const makeStripe: React.FC<StripeProps> = ({ color, index }) => (
   <StripeSvg
     index={index}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,6 +6,7 @@ import Banner from "../sections/Banner";
 import About from "../sections/About";
 import Events from "../sections/Events";
 import Join from "../sections/Join";
+import MainStripe from "../components/MainStripe";
 
 const IndexPage: React.FC = () => (
   <Layout>
@@ -22,6 +23,7 @@ const IndexPage: React.FC = () => (
       ]}
     />
     <Banner />
+    <MainStripe />
     <Events />
     <About />
     <Join />

--- a/src/sections/banner.tsx
+++ b/src/sections/banner.tsx
@@ -10,6 +10,7 @@ const BannerText = styled.h1`
   font-size: 5em;
   font-weight: 900;
   letter-spacing: 0.05em;
+  margin-bottom: 0;
   text-align: center;
   text-shadow: ${textStriper({
     colorArray: [stripes.yellow, stripes.red],

--- a/src/styles/colors.tsx
+++ b/src/styles/colors.tsx
@@ -5,14 +5,15 @@ export const acadianaFlag = {
   yellow: "#fd0",
 };
 
+export const primaryColor = acadianaFlag.blue;
+export const secondaryColor = acadianaFlag.red;
+
 /**
  * Colors for stripes in acronym and design elements
  */
 export const stripes = {
+  blue: primaryColor,
   white: "#fff",
   yellow: acadianaFlag.yellow,
   red: acadianaFlag.red
 }
-
-export const primaryColor = acadianaFlag.blue;
-export const secondaryColor = acadianaFlag.red;


### PR DESCRIPTION
Did not address the text alignments for sections before and after the stripe.

Could probably expose the dynamic properties a little better, but I didn't want to get too involved in case the section alignments require more fiddling.

Will need some breakpoints for extreme screen sizes (4k seems fine, but super tiny starts clipping).  We can address breakpoints system-wide in a separate issue/branch.